### PR TITLE
Environment variable for local db

### DIFF
--- a/server/graffiti/graffiti.cfg
+++ b/server/graffiti/graffiti.cfg
@@ -1,2 +1,2 @@
 PG_DB_NAME = 'mydb'
-SQLALCHEMY_DATABASE_URI = 'postgresql://graffiti_owner:graf220Shan@graffiti.ctpw3jh7jyoj.us-east-1.rds.amazonaws.com:5432/graffiti'
+SQLALCHEMY_DATABASE_URI = 'postgresql://localhost:mydb'

--- a/server/graffiti/graffiti.py
+++ b/server/graffiti/graffiti.py
@@ -8,14 +8,14 @@ from oauth2client import client, crypt
 from flask.ext.sqlalchemy import SQLAlchemy
 
 import os
-LOCAL_DB = False
-if 'LOCAL' in os.environ and os.environ['LOCAL'] == 'True':
-	LOCAL_DB = True
+DB = ''
+if 'GRAFFITI_DB' in os.environ:
+	DB = os.environ['GRAFFITI_DB']
 
 app = Flask(__name__)
 app.config.from_pyfile('graffiti.cfg')
-if LOCAL_DB:
-	app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://localhost/mydb'
+if DB:
+	app.config['SQLALCHEMY_DATABASE_URI'] = DB
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['MAX_CONTENT_LENGTH'] = 200 * 1024 * 1024
 db = SQLAlchemy(app)
@@ -84,7 +84,8 @@ def fill_db():
 	db.session.commit()
 	return 'added sample records\n'
 
-if LOCAL_DB:
+# If its the default db, i.e. the local db
+if not DB or DB == 'postgresql://localhost:mydb':
 	print init_db()
 	print clear_db_of_everything()
 	print fill_db()

--- a/server/tests/run_all_tests.sh
+++ b/server/tests/run_all_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # tells the server to use the local database, not the production one
-export LOCAL=True
+export GRAFFITI_DB=postgresql://localhost:mydb
 
 python auth_api_test.py
 python user_api_test.py


### PR DESCRIPTION
Before running tests/local server, to point at the local db run `export LOCAL=True` on the command line so that it connects to a local database instead of the production one.